### PR TITLE
Prevent assignment to undeclared variable errors

### DIFF
--- a/src/leaflet-touch-extend.js
+++ b/src/leaflet-touch-extend.js
@@ -30,7 +30,7 @@ L.Map.TouchExtend = L.Handler.extend({
         x = touch.clientX - rect.left - this._container.clientLeft,
         y = touch.clientY - rect.top - this._container.clientTop,
         containerPoint = L.point(x, y),
-        layerPoint = this._map.containerPointToLayerPoint(containerPoint);
+        layerPoint = this._map.containerPointToLayerPoint(containerPoint),
         latlng = this._map.containerPointToLatLng(containerPoint);
 
     this._map.fire(type, {
@@ -52,7 +52,7 @@ L.Map.TouchExtend = L.Handler.extend({
         x = touch.clientX - rect.left - this._container.clientLeft,
         y = touch.clientY - rect.top - this._container.clientTop,
         containerPoint = L.point(x, y),
-        layerPoint = this._map.containerPointToLayerPoint(containerPoint);
+        layerPoint = this._map.containerPointToLayerPoint(containerPoint),
         latlng = this._map.containerPointToLatLng(containerPoint);
 
     this._map.fire(type, {


### PR DESCRIPTION
This may be a small typo I have just detected (and fixed). The variable `latlng` was not declared an thus it raises an error because it doesn't exist.

After you merge this PR, can you please publish a new version for NPM?

Thanks in advance!