### PR TITLE
fix: on/off on actual function rather than a copy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ L.FreeHandShapes = L.FeatureGroup.extend({
         }
 
         // body events
-        L.DomEvent[ onoff ](document.body, 'mouseleave', this.mouseUpLeave.bind(this));
+        L.DomEvent[ onoff ](document.body, 'mouseleave', this.mouseUpLeave, this);
     },
 
     drawStartedEvents : function (onoff) {


### PR DESCRIPTION
Was having some issues in an Angular app when attempting to destroy and then re-initialize a new FreehandShapes instance – turns out there was an issue with the destruction of the event binding (the handlers weren't properly being destroyed, leading them to trigger when the component should have been destroyed).